### PR TITLE
Require a software package metadata spec

### DIFF
--- a/license-metadata-exception.md
+++ b/license-metadata-exception.md
@@ -2,4 +2,4 @@ Any requirement to include, reproduce, or otherwise communicate information abou
 
 "Information about this license" means any intellectual property ownership notice, disclaimer, limitation of liability, license terms, or other information about this license.
 
-"Standard metadata" means metadata representing information about this license according to a widely understood technical specification (or technical standard) published free of charge on the Internet.
+"Standard metadata" means metadata representing information about this license according to a widely understood software package metadata specification published free of charge on the Internet.


### PR DESCRIPTION
This PR makes the definition of "standard metadata" more specific by requiring use of a _software page_ specification, rather than just any convention or specification.

@anseljh, I'd be very grateful for your thoughts on this!
